### PR TITLE
Add test and release workflows to build multi-arch Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  github:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Version ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+
+  docker-hub:
+    needs: github
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: zappi/celery-exporter
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: danihodovic/celery-exporter
+          ref: "v${{ github.ref_name }}"
+      - name: Prepare Image Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login To Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build, tag, and push image to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          annotations: ${{ steps.metadata.outputs.annotations }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+      - name: Update Description On Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  # Update this to the exact version that you want to test i.e. the packaging
+  # into a Docker image.
+  VERSION: 0.10.14
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: zappi/celery-exporter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: danihodovic/celery-exporter
+          ref: v${{ env.VERSION }}
+      - name: Prepare Image Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+      - name: Set Up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set Up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test Multi-Arch Building Of Image
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          annotations: ${{ steps.metadata.outputs.annotations }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Intellection/SRE

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Intellection
+Copyright (c) 2024 Zappi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # docker-celery-exporter
-Docker image for celery-exporter, a Prometheus exporter for Celery metrics
+
+Docker image for [`danihodovic/celery-exporter`](https://github.com/danihodovic/celery-exporter), a Prometheus exporter for Celery metrics.
+
+## Motivations
+
+### How does this differ from upstream?
+
+The current Docker image doesn't support ARM and we needed one that does. And [the review to add support](https://github.com/danihodovic/celery-exporter/pull/329) took longer than we could wait.
+
+## Usage
+
+```
+docker run --name celery-exporter zappi/celery-exporter:latest
+```
+
+For more detailed usage documentation [see upstream](https://github.com/danihodovic/celery-exporter).


### PR DESCRIPTION
Pretty much packages the upstream `celery-exporter` as a multi-arch Docker image supporting AMD64 and ARM64. The current Docker image doesn't support ARM and we needed one that does. And https://github.com/danihodovic/celery-exporter/pull/329 took longer than we could wait.

### References

* https://hub.docker.com/repository/docker/zappi/celery-exporter

### Related

* https://github.com/danihodovic/celery-exporter/pull/329