### PR TITLE
Update tests to use v0.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Update this to the exact version that you want to test i.e. the packaging
   # into a Docker image.
-  VERSION: 0.10.14
+  VERSION: 0.11.0
 
 jobs:
   docker-build:


### PR DESCRIPTION
Because [there's a new version i.e. `v0.11.0`](https://github.com/danihodovic/celery-exporter/releases/tag/v0.11.0).

### Changes

* https://github.com/danihodovic/celery-exporter/pull/338
* https://github.com/danihodovic/celery-exporter/pull/339